### PR TITLE
Enable processing of degenerate base notation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,10 @@ fn encode_single(c: u8) -> [bool; 5] {
         b'C' => [false, true, false, false, false],
         b'G' => [false, false, true, false, false],
         b'T' => [false, false, false, true, false],
-        b'N' | b'-' => [false, false, false, false, true],
+        b'U' => [false, false, false, true, false],
+        b'N' | b'-' | b'W' | b'S' | b'M' | b'K' | b'R' | b'Y' | b'B' | b'D' | b'H' | b'V' => {
+            [false, false, false, false, true]
+        }
         _ => {
             panic!("Invalid character in query sequence: {c}")
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn build_cli() -> Command {
                 1. Query sequence number (0-indexed)\n\
                 2. Subject sequence number (0-indexed)\n\
                 3. Divergence (number of nucleotides different between the two sequences\n\
-                4. Subject sequence (except dashes are shown as Ns)")
+                4. Subject sequence (with dashes and degenerate base symbols shown as Ns)")
                 .arg(arg!(-d --database <FILE> "Output from makedb [required]"))
                 .arg(arg!(-q --query <FILE> "Query sequences to search with in FASTX format [required]"))
                 .arg(

--- a/tests/data/degenerate.fna
+++ b/tests/data/degenerate.fna
@@ -1,0 +1,6 @@
+>1
+CTTRGG
+>2
+AGGUGA
+>3
+YACTTT

--- a/tests/test_cmdline.rs
+++ b/tests/test_cmdline.rs
@@ -40,16 +40,20 @@ mod tests {
                 t,
                 "-q",
                 "tests/data/degenerate.fna",
-                "--max-divergence",
-                "3",
                 "--max-num-hits",
                 "99",
             ])
             .succeeds()
             .stdout()
             .is("0	0	0	CTTNGG\n\
+                0	1	5	AGGTGA\n\
+                0	2	6	NACTTT\n\
                 1	1	0	AGGTGA\n\
-                2	2	0	NACTTT\n")
+                1	0	5	CTTNGG\n\
+                1	2	5	NACTTT\n\
+                2	2	0	NACTTT\n\
+                2	1	5	AGGTGA\n\
+                2	0	6	CTTNGG\n")
             .unwrap()
     }
 

--- a/tests/test_cmdline.rs
+++ b/tests/test_cmdline.rs
@@ -25,6 +25,33 @@ mod tests {
     }
 
     #[test]
+    fn test_degenerate_makedb_and_query() {
+        let tf: tempfile::NamedTempFile = tempfile::NamedTempFile::new().unwrap();
+        let t = tf.path().to_str().unwrap();
+        Assert::main_binary()
+            .with_args(&["makedb", "-i", "tests/data/degenerate.fna", "-d", t])
+            .succeeds()
+            .unwrap();
+
+        Assert::main_binary()
+            .with_args(&[
+                "query",
+                "-d",
+                t,
+                "-q",
+                "tests/data/degenerate.fna",
+                "--max-divergence",
+                "3",
+            ])
+            .succeeds()
+            .stdout()
+            .is("0	0	0	CTTNGG\n\
+                1	1	0	AGGTGA\n\
+                2	2	0	NACTTT\n")
+            .unwrap()
+    }
+
+    #[test]
     fn test_query_max_divergence_unlimited() {
         Assert::main_binary()
             .with_args(&[

--- a/tests/test_cmdline.rs
+++ b/tests/test_cmdline.rs
@@ -42,6 +42,8 @@ mod tests {
                 "tests/data/degenerate.fna",
                 "--max-divergence",
                 "3",
+                "--max-num-hits",
+                "99",
             ])
             .succeeds()
             .stdout()


### PR DESCRIPTION
Defaults degenerate bases as N, Uracil as T.