### PR TITLE
cluster: pidgeonhole and mutltithreading

### DIFF
--- a/BANDING_BENCHMARK.md
+++ b/BANDING_BENCHMARK.md
@@ -1,0 +1,178 @@
+# Banding strategy benchmark (query)
+
+Question (from the design discussion): for the `query` pigeonhole prefilter, is
+**balancing column conservation across bands** worth a new database format,
+compared to (a) the current single contiguous band, and (b) the simpler
+"offset by (d+1)/2 and wrap" second band?
+
+## What was compared
+
+All four are *exact* — each partition has `d+1` bands, so by pigeonhole every
+within-`d` subject shares a band in every partition; intersecting two partitions
+keeps all true hits and only drops false positives. The benchmark verifies this:
+**all four return byte-identical within-`d` hit sets** for every query.
+
+| method | partitions | how the columns are cut | DB-format change |
+|---|---|---|---|
+| `1-contiguous` | 1 | `d+1` equal contiguous bands (**current default**) | none |
+| `1-balanced` | 1 | columns round-robin'd by conservation so every band has equal collision-entropy | column→band map |
+| `2-offset-wrap` | 2 | contiguous + the same cut rotated half a band, wrapped; candidates intersected | none |
+| `2-balanced-diag` | 2 | two balanced partitions in the diagonal Latin-square layout; intersected | column→band map |
+
+`mean_cand` is the mean number of candidate subjects scanned per query (the work
+that drives speed); `scan_s` is the wall time for keys + candidate-gen + Hamming
+over all queries, single-threaded.
+
+## Results
+
+Database: `S3.10.ribosomal_protein_S19_rpsS` (136,770 subjects, 60 bp).
+Queries: `1000000.S3.10.seqs.fna`, first 200,000.
+
+```
+# d=2  bands/partition=3
+method             parts  mean_cand   max_cand   scan_s
+1-contiguous           1     131.31       2884    0.592
+1-balanced             1      56.18       1445    0.410   <- fastest
+2-offset-wrap          2      19.72        763    0.734
+2-balanced-diag        2      11.03        513    0.672
+
+# d=3  bands/partition=4
+1-contiguous           1     701.07       7974    3.590
+1-balanced             1     375.12       4636    2.070   <- fastest
+2-offset-wrap          2     143.50       3687    4.778
+2-balanced-diag        2      57.54       1994    2.709
+
+# d=5  bands/partition=6
+1-contiguous           1    6155.60      29654   35.273
+1-balanced             1    3592.34      18835   21.378   <- fastest
+2-offset-wrap          2    2136.29      19442   68.286
+2-balanced-diag        2     670.02       8141   28.407
+```
+
+The full 1,000,000-query run reproduces the same ordering:
+
+```
+            1-contiguous  1-balanced  2-offset-wrap  2-balanced-diag
+d=2 scan_s        8.413       5.453         11.968            7.092
+d=3 scan_s       28.513      18.058         39.709           22.905
+```
+
+Reproduce with:
+
+```
+smafa bench-banding -d <db> -q 1000000.S3.10.seqs.fna --divergences 2 3 5
+```
+
+## Conclusion
+
+**Balancing is worth it; a second partition for `query` is not.**
+
+- **`1-balanced` is the fastest at every `d`** (≈1.4× at d=2 up to ≈1.65× at
+  d=5 over the current contiguous band) and it cuts candidates ≈1.7–2.3×. It
+  costs only the column→band map in the DB and **no extra lookups**, so there is
+  no per-query overhead to pay back. This is the change that earns the new
+  database format.
+
+- **The 2-partition methods reduce *candidates* a lot but lose on *wall time*.**
+  `2-offset-wrap` cuts candidates 6–8× yet is consistently **slower than the
+  baseline** (e.g. 68 s vs 35 s at d=5). On real coding data the cost is
+  dominated by *gathering and sorting the conserved-band buckets*, not by the
+  final Hamming checks — and a second contiguous partition has the same conserved
+  bands, so it doubles the expensive part to shrink the cheap part. This is the
+  opposite of the uniform-random expectation, and exactly the "measure on real
+  data" caveat from the design discussion.
+
+- **`2-balanced-diag` gives by far the smallest candidate sets** (9× at d=5) and
+  beats the baseline on time, but is still slower than `1-balanced` because of
+  the second partition's overhead. It only becomes attractive if you are
+  candidate-/RAM-bound, or if the per-candidate cost downstream were much higher
+  than a 5-word Hamming distance — neither is true here.
+
+Why balancing helps so much on this data: the windows are back-translated
+protein, so conservation is wildly uneven across columns. A *contiguous* band can
+land entirely inside a conserved region, producing one near-zero-entropy band
+whose bucket holds most of the database — that single bucket dominates both the
+candidate count and the gather/sort cost. Round-robining columns by conservation
+guarantees no band is all-conserved, which removes the giant bucket. That is also
+why `2-balanced-diag` (28 s) is much faster than `2-offset-wrap` (68 s) at d=5
+despite both being two-partition: the win is from killing giant buckets, not from
+the number of partitions.
+
+## Cluster
+
+`cluster` streams sequences and has no pre-built DB, but it can estimate
+per-column conservation from the **first block** of input (≤8192 unique
+sequences) and build a single balanced partition on the fly — no stored format
+needed. The partition choice never changes cluster output (verified byte-identical
+to `--no-banding` for every strategy). Wall time, 200k input sequences, single
+thread:
+
+```
+ d   contiguous  offset-wrap  balanced  no-banding
+ 2     1.61        1.80        1.61       19.70
+ 3     1.55        1.82        1.45       16.09
+ 5     2.24        4.32        1.79       10.78
+```
+
+The full 1,000,000-sequence run widens the gaps:
+
+```
+ d   contiguous  offset-wrap  balanced
+ 3     12.48       18.15        9.26
+ 5     44.81       85.35       25.46
+```
+
+At 1M/d=5 `balanced` is 1.76× faster than `contiguous` and 3.35× faster than
+`offset-wrap`.
+
+Same story as query, and it settles the "is offset+wrap worth it for cluster?"
+question: **no.** `offset-wrap` is the *slowest* banded option (≈2× `contiguous`
+at d=5) because the second contiguous partition doubles the conserved-bucket
+work. **`balanced` (entropy from the first block) is fastest at every `d`** and
+needs no extra partition and no stored format — exactly the "compute entropy from
+the first ~10k sequences then use the 1-balanced partition like query" idea.
+
+`cluster` now defaults to `balanced`; `--banding offset-wrap|contiguous` are kept
+for benchmarking.
+
+## Cost of the entropy computation (and: does it need to be stored?)
+
+`column_weights` over all 136,770 subjects takes **~10.6 ms** (measured, scales
+linearly with subject count; independent of the queries and of `d`). Deriving any
+`d`'s partition from the weights is a 60-element sort + round-robin —
+microseconds.
+
+Put that next to the other per-invocation costs: deserialising the 6.3 MB DB is
+~hundreds of ms, and an actual query pass is seconds. So the entropy step is
+~2–3% of DB load and a fraction of a percent of a query pass.
+
+Two consequences:
+
+- **No new DB format is needed for balanced `query` after all.** The partition is
+  a deterministic function of the subjects, so `query` can just recompute the
+  weights at load (~10 ms) and build the same partition `makedb` would have. This
+  is the same trick `cluster` already uses (estimate from the data on the fly),
+  only `query` has *all* the subjects available so it doesn't even need to
+  subsample.
+
+- **Caching the partition in the DB is not worth it — including for d=2.** It
+  would save ~10 ms per invocation, dwarfed by the DB deserialize that every
+  invocation already pays. Even under heavy fan-out (many small query runs against
+  one DB) the load cost dominates the 10 ms. If you ever did want to remove it,
+  cache the 60 per-column weights (≈480 bytes, `d`-independent) rather than a
+  specific `d`'s partition — but the payoff is still only ~10 ms.
+
+## Recommendation
+
+- **`cluster`: use the balanced partition** (now the default), conservation
+  estimated from the first block. Drop offset+wrap as a clustering default.
+- **`query`: use a single entropy-balanced partition, recomputed at load.** No DB
+  format change: compute per-column conservation from the loaded subjects (~10 ms)
+  and build the single band index from it. Skip the second partition (it cuts
+  candidates but loses on wall time on this data).
+
+Following this benchmark, the two-partition strategies (`offset-wrap` and
+`balanced-diag`) have been **removed from the code**. Only the two single-partition
+strategies remain: `contiguous` (`BandIndex::new`) and `balanced`
+(`BandIndex::single_balanced`). `cluster` defaults to `balanced`; the
+`bench-banding` subcommand compares the two on a real DB + query set.

--- a/BANDING_BENCHMARK.md
+++ b/BANDING_BENCHMARK.md
@@ -171,8 +171,11 @@ Two consequences:
   and build the single band index from it. Skip the second partition (it cuts
   candidates but loses on wall time on this data).
 
-Following this benchmark, the two-partition strategies (`offset-wrap` and
-`balanced-diag`) have been **removed from the code**. Only the two single-partition
-strategies remain: `contiguous` (`BandIndex::new`) and `balanced`
-(`BandIndex::single_balanced`). `cluster` defaults to `balanced`; the
-`bench-banding` subcommand compares the two on a real DB + query set.
+Following this benchmark, **balanced is the only production banding**: both
+`query` and `cluster` use `BandIndex::single_balanced` (query recomputes the
+weights from the loaded subjects; cluster estimates them from the first input
+block). The two-partition strategies (`offset-wrap`, `balanced-diag`) are gone,
+and contiguous banding is no longer selectable in production. `BandIndex::new`
+(contiguous) is retained only as the baseline inside the `bench-banding`
+subcommand, which still compares contiguous vs balanced on a real DB + query set
+so this result stays reproducible.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ bird_tool_utils = "0.4"
 # bird_tool_utils = { path = "../bird_tool_utils" }
 needletail = "0.5"
 serde_json = "1.0"
+rayon = "1.10"
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -16,19 +16,6 @@ use crate::{hamming, BandIndex, SeqEncoding, SeqEncodingLength, WindowSet};
 /// reconciliation cost, which is bounded by O(BLOCK_SIZE^2) per block.
 const BLOCK_SIZE: usize = 8192;
 
-/// Which pigeonhole partitioning to use for the banding prefilter. Both choices
-/// produce identical clustering output (every valid `d+1`-band partition is
-/// exact by pigeonhole); they only differ in how many false candidates get
-/// scanned, i.e. in speed.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ClusterBanding {
-    /// `d+1` equal contiguous bands (the original scheme).
-    Contiguous,
-    /// One entropy-balanced partition, with per-column conservation estimated
-    /// from the first block of input sequences. Faster on coding data.
-    Balanced,
-}
-
 /// Greedy single-linkage-style centroid clustering, parallelised by block
 /// (phase 1 across sequences) and, when divergence is small relative to the
 /// sequence length, accelerated with a pigeonhole/banding index so that each
@@ -42,7 +29,6 @@ pub fn cluster(
     input_fasta: &Path,
     max_divergence: u32,
     no_banding: bool,
-    banding: ClusterBanding,
     print_stream: &mut dyn std::io::Write,
 ) -> Result<(), Box<dyn Error>> {
     let start = Instant::now();
@@ -102,19 +88,19 @@ pub fn cluster(
         if !initialized {
             let len = block[0].1.len;
             // Banding needs d + 1 < len to guarantee a shared band for every
-            // within-d pair; otherwise fall back to full scans. The partition
-            // choice never changes the output (any d+1-band partition is exact),
-            // only how many false candidates are scanned.
+            // within-d pair; otherwise fall back to full scans. The entropy-
+            // balanced partition never changes the output (any d+1-band partition
+            // is exact), it just scans fewer false candidates than contiguous
+            // bands on coding data. Per-column conservation is estimated from the
+            // first block of input sequences.
             if !no_banding && max_divergence_usize + 1 < len {
-                band_index = Some(match banding {
-                    ClusterBanding::Contiguous => BandIndex::new(max_divergence_usize, len),
-                    ClusterBanding::Balanced => {
-                        // Estimate per-column conservation from the first block.
-                        let sample: Vec<SeqEncoding> =
-                            block.iter().map(|(_, enc)| enc.encoding.clone()).collect();
-                        BandIndex::single_balanced(max_divergence_usize, len, &sample)
-                    }
-                });
+                let sample: Vec<SeqEncoding> =
+                    block.iter().map(|(_, enc)| enc.encoding.clone()).collect();
+                band_index = Some(BandIndex::single_balanced(
+                    max_divergence_usize,
+                    len,
+                    &sample,
+                ));
             }
             initialized = true;
         }
@@ -217,29 +203,18 @@ mod tests {
     use super::*;
     use std::io::Cursor;
 
-    /// Run `cluster` with every banding strategy (plus no-banding) and assert
-    /// they all produce `expected` — the output must not depend on the partition.
+    /// Run `cluster` both banded (balanced) and unbanded and assert both produce
+    /// `expected` — the output must not depend on the prefilter.
     fn assert_all_strategies(file: &str, d: u32, expected: &str) {
-        for banding in [ClusterBanding::Contiguous, ClusterBanding::Balanced] {
+        for no_banding in [false, true] {
             let mut stream = Cursor::new(Vec::new());
-            cluster(Path::new(file), d, false, banding, &mut stream).unwrap();
+            cluster(Path::new(file), d, no_banding, &mut stream).unwrap();
             assert_eq!(
                 expected,
                 std::str::from_utf8(stream.get_ref()).unwrap(),
-                "banded output differs for {banding:?}"
+                "output differs for no_banding={no_banding}"
             );
         }
-        // no-banding (full scan) must match too.
-        let mut stream = Cursor::new(Vec::new());
-        cluster(
-            Path::new(file),
-            d,
-            true,
-            ClusterBanding::Contiguous,
-            &mut stream,
-        )
-        .unwrap();
-        assert_eq!(expected, std::str::from_utf8(stream.get_ref()).unwrap());
     }
 
     #[test]

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,128 +1,20 @@
 use needletail::parse_fastx_file;
 use rayon::prelude::*;
 
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;
-use std::hash::{BuildHasherDefault, Hasher};
 use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::time::Instant;
 
 use log::info;
 
-use crate::{SeqEncoding, SeqEncodingLength, WindowSet};
+use crate::{hamming, BandIndex, SeqEncodingLength, WindowSet};
 
 /// Number of unique input sequences processed per parallel block. Larger blocks
 /// expose more parallelism in phase 1, but increase the serial phase-2
 /// reconciliation cost, which is bounded by O(BLOCK_SIZE^2) per block.
 const BLOCK_SIZE: usize = 8192;
-
-/// Hamming distance between two equal-length packed encodings, in number of
-/// differing nucleotide positions. Each mismatch flips two bits in the 5-bit
-/// one-hot encoding, hence the `/ 2`.
-#[inline]
-fn hamming(a: &SeqEncoding, b: &SeqEncoding) -> usize {
-    a.0.iter()
-        .zip(b.0.iter())
-        .map(|(x, y)| (x ^ y).count_ones() as usize)
-        .sum::<usize>()
-        / 2
-}
-
-/// FNV-1a hash of the (canonical) 5-bit codes covering nucleotide positions
-/// `[start, end)` of an encoding. Identical band content always yields an
-/// identical key; hash collisions only ever add extra candidates (never drop
-/// true ones), so they cost time, not correctness.
-#[inline]
-fn band_hash(enc: &SeqEncoding, start: usize, end: usize) -> u64 {
-    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-    for i in start..end {
-        let code = (enc.0[i / 12] >> (5 * (i % 12))) & 0x1f;
-        h ^= code;
-        h = h.wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    h
-}
-
-/// Identity hasher for band keys: the keys are already well-mixed FNV hashes,
-/// so we avoid SipHash and bucket directly on the u64.
-#[derive(Default)]
-struct U64Hasher(u64);
-impl Hasher for U64Hasher {
-    #[inline]
-    fn finish(&self) -> u64 {
-        self.0
-    }
-    #[inline]
-    fn write_u64(&mut self, i: u64) {
-        self.0 = i;
-    }
-    fn write(&mut self, bytes: &[u8]) {
-        for &b in bytes {
-            self.0 = self.0.rotate_left(8) ^ b as u64;
-        }
-    }
-}
-type U64Map = HashMap<u64, Vec<u32>, BuildHasherDefault<U64Hasher>>;
-
-/// Pigeonhole / banding index over centroids.
-///
-/// For a maximum Hamming divergence `d`, the sequence is split into `d + 1`
-/// disjoint contiguous bands. Any two sequences within distance `d` must have
-/// at least one band that is identical (d mismatches cannot touch all d+1
-/// bands), so a centroid within `d` of a query is guaranteed to share a band
-/// with it. The index therefore lets us restrict the (expensive) full-distance
-/// comparisons to centroids that share at least one band, turning the greedy
-/// scan from O(K) per query towards near-constant when clusters are dense.
-///
-/// This is exact for Hamming distance: it never misses a centroid within `d`.
-/// (Used only when `d + 1 < len`; otherwise a single all-differing pair could
-/// share no band, so the caller falls back to a full scan.)
-struct BandIndex {
-    bounds: Vec<(usize, usize)>,
-    maps: Vec<U64Map>,
-}
-
-impl BandIndex {
-    fn new(max_divergence: usize, len: usize) -> Self {
-        let num_bands = (max_divergence + 1).min(len.max(1));
-        let bounds = (0..num_bands)
-            .map(|i| (i * len / num_bands, (i + 1) * len / num_bands))
-            .collect();
-        let maps = (0..num_bands).map(|_| U64Map::default()).collect();
-        BandIndex { bounds, maps }
-    }
-
-    fn keys(&self, enc: &SeqEncoding) -> Vec<u64> {
-        self.bounds
-            .iter()
-            .map(|&(s, e)| band_hash(enc, s, e))
-            .collect()
-    }
-
-    /// Centroid indices that share at least one band with the given keys,
-    /// sorted ascending and deduplicated. Ascending order means a later
-    /// strict-`<` scan keeps the lowest-index centroid on distance ties,
-    /// matching the original greedy behaviour.
-    fn candidates_sorted(&self, keys: &[u64]) -> Vec<u32> {
-        let mut v = Vec::new();
-        for (b, &k) in keys.iter().enumerate() {
-            if let Some(list) = self.maps[b].get(&k) {
-                v.extend_from_slice(list);
-            }
-        }
-        v.sort_unstable();
-        v.dedup();
-        v
-    }
-
-    fn insert(&mut self, idx: u32, keys: &[u64]) {
-        for (b, &k) in keys.iter().enumerate() {
-            self.maps[b].entry(k).or_default().push(idx);
-        }
-    }
-}
 
 /// Greedy single-linkage-style centroid clustering, parallelised by block
 /// (phase 1 across sequences) and, when divergence is small relative to the

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -28,6 +28,7 @@ const BLOCK_SIZE: usize = 8192;
 pub fn cluster(
     input_fasta: &Path,
     max_divergence: u32,
+    no_banding: bool,
     print_stream: &mut dyn std::io::Write,
 ) -> Result<(), Box<dyn Error>> {
     let start = Instant::now();
@@ -88,7 +89,7 @@ pub fn cluster(
             let len = block[0].1.len;
             // Banding needs d + 1 < len to guarantee a shared band for every
             // within-d pair; otherwise fall back to full scans.
-            if max_divergence_usize + 1 < len {
+            if !no_banding && max_divergence_usize + 1 < len {
                 band_index = Some(BandIndex::new(max_divergence_usize, len));
             }
             initialized = true;
@@ -195,7 +196,13 @@ mod tests {
     #[test]
     fn test_simple() {
         let mut stream = Cursor::new(Vec::new());
-        cluster(Path::new("tests/data/cluster_dummy1.fna"), 1, &mut stream).unwrap();
+        cluster(
+            Path::new("tests/data/cluster_dummy1.fna"),
+            1,
+            false,
+            &mut stream,
+        )
+        .unwrap();
         assert_eq!(
             "ATGC\tATGC
 ATGG\tATGC
@@ -208,7 +215,13 @@ AAAA\tAAAA
     #[test]
     fn test_bug1() {
         let mut stream = Cursor::new(Vec::new());
-        cluster(Path::new("tests/data/cluster_bug1.fna"), 2, &mut stream).unwrap();
+        cluster(
+            Path::new("tests/data/cluster_bug1.fna"),
+            2,
+            false,
+            &mut stream,
+        )
+        .unwrap();
         assert_eq!(
             "ATGCAAAAA\tATGCAAAAA\n\
              ATAAAAAAA\tATGCAAAAA\n\
@@ -225,6 +238,7 @@ AAAA\tAAAA
         cluster(
             Path::new("tests/data/cluster_best_hit_changes.fna"),
             2,
+            false,
             &mut stream,
         )
         .unwrap();

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -9,12 +9,25 @@ use std::time::Instant;
 
 use log::info;
 
-use crate::{hamming, BandIndex, SeqEncodingLength, WindowSet};
+use crate::{hamming, BandIndex, SeqEncoding, SeqEncodingLength, WindowSet};
 
 /// Number of unique input sequences processed per parallel block. Larger blocks
 /// expose more parallelism in phase 1, but increase the serial phase-2
 /// reconciliation cost, which is bounded by O(BLOCK_SIZE^2) per block.
 const BLOCK_SIZE: usize = 8192;
+
+/// Which pigeonhole partitioning to use for the banding prefilter. Both choices
+/// produce identical clustering output (every valid `d+1`-band partition is
+/// exact by pigeonhole); they only differ in how many false candidates get
+/// scanned, i.e. in speed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClusterBanding {
+    /// `d+1` equal contiguous bands (the original scheme).
+    Contiguous,
+    /// One entropy-balanced partition, with per-column conservation estimated
+    /// from the first block of input sequences. Faster on coding data.
+    Balanced,
+}
 
 /// Greedy single-linkage-style centroid clustering, parallelised by block
 /// (phase 1 across sequences) and, when divergence is small relative to the
@@ -29,6 +42,7 @@ pub fn cluster(
     input_fasta: &Path,
     max_divergence: u32,
     no_banding: bool,
+    banding: ClusterBanding,
     print_stream: &mut dyn std::io::Write,
 ) -> Result<(), Box<dyn Error>> {
     let start = Instant::now();
@@ -88,9 +102,19 @@ pub fn cluster(
         if !initialized {
             let len = block[0].1.len;
             // Banding needs d + 1 < len to guarantee a shared band for every
-            // within-d pair; otherwise fall back to full scans.
+            // within-d pair; otherwise fall back to full scans. The partition
+            // choice never changes the output (any d+1-band partition is exact),
+            // only how many false candidates are scanned.
             if !no_banding && max_divergence_usize + 1 < len {
-                band_index = Some(BandIndex::new(max_divergence_usize, len));
+                band_index = Some(match banding {
+                    ClusterBanding::Contiguous => BandIndex::new(max_divergence_usize, len),
+                    ClusterBanding::Balanced => {
+                        // Estimate per-column conservation from the first block.
+                        let sample: Vec<SeqEncoding> =
+                            block.iter().map(|(_, enc)| enc.encoding.clone()).collect();
+                        BandIndex::single_balanced(max_divergence_usize, len, &sample)
+                    }
+                });
             }
             initialized = true;
         }
@@ -193,60 +217,61 @@ mod tests {
     use super::*;
     use std::io::Cursor;
 
-    #[test]
-    fn test_simple() {
+    /// Run `cluster` with every banding strategy (plus no-banding) and assert
+    /// they all produce `expected` — the output must not depend on the partition.
+    fn assert_all_strategies(file: &str, d: u32, expected: &str) {
+        for banding in [ClusterBanding::Contiguous, ClusterBanding::Balanced] {
+            let mut stream = Cursor::new(Vec::new());
+            cluster(Path::new(file), d, false, banding, &mut stream).unwrap();
+            assert_eq!(
+                expected,
+                std::str::from_utf8(stream.get_ref()).unwrap(),
+                "banded output differs for {banding:?}"
+            );
+        }
+        // no-banding (full scan) must match too.
         let mut stream = Cursor::new(Vec::new());
         cluster(
-            Path::new("tests/data/cluster_dummy1.fna"),
-            1,
-            false,
+            Path::new(file),
+            d,
+            true,
+            ClusterBanding::Contiguous,
             &mut stream,
         )
         .unwrap();
-        assert_eq!(
-            "ATGC\tATGC
-ATGG\tATGC
-AAAA\tAAAA
-",
-            std::str::from_utf8(stream.get_ref()).unwrap()
-        )
+        assert_eq!(expected, std::str::from_utf8(stream.get_ref()).unwrap());
+    }
+
+    #[test]
+    fn test_simple() {
+        assert_all_strategies(
+            "tests/data/cluster_dummy1.fna",
+            1,
+            "ATGC\tATGC\nATGG\tATGC\nAAAA\tAAAA\n",
+        );
     }
 
     #[test]
     fn test_bug1() {
-        let mut stream = Cursor::new(Vec::new());
-        cluster(
-            Path::new("tests/data/cluster_bug1.fna"),
+        assert_all_strategies(
+            "tests/data/cluster_bug1.fna",
             2,
-            false,
-            &mut stream,
-        )
-        .unwrap();
-        assert_eq!(
             "ATGCAAAAA\tATGCAAAAA\n\
              ATAAAAAAA\tATGCAAAAA\n\
              TTAAAAAAA\tTTAAAAAAA\n",
-            std::str::from_utf8(stream.get_ref()).unwrap()
-        )
+        );
     }
 
     #[test]
     fn test_best_hit_changes_bug() {
         // seq4 in the file shouldn't be reported otherwise there are two
         // sequences that are the same but are given different centroids.
-        let mut stream = Cursor::new(Vec::new());
-        cluster(
-            Path::new("tests/data/cluster_best_hit_changes.fna"),
+        assert_all_strategies(
+            "tests/data/cluster_best_hit_changes.fna",
             2,
-            false,
-            &mut stream,
-        )
-        .unwrap();
-        assert_eq!(
             "ATGCAAAAA\tATGCAAAAA\n\
              ATAAAAAAA\tATGCAAAAA\n\
              TTAAAAAAA\tTTAAAAAAA\n",
-            std::str::from_utf8(stream.get_ref()).unwrap()
-        )
+        );
     }
 }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,15 +1,138 @@
 use needletail::parse_fastx_file;
+use rayon::prelude::*;
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;
+use std::hash::{BuildHasherDefault, Hasher};
+use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::time::Instant;
 
-use log::debug;
 use log::info;
 
-use crate::{SeqEncodingLength, WindowSet};
+use crate::{SeqEncoding, SeqEncodingLength, WindowSet};
 
+/// Number of unique input sequences processed per parallel block. Larger blocks
+/// expose more parallelism in phase 1, but increase the serial phase-2
+/// reconciliation cost, which is bounded by O(BLOCK_SIZE^2) per block.
+const BLOCK_SIZE: usize = 8192;
+
+/// Hamming distance between two equal-length packed encodings, in number of
+/// differing nucleotide positions. Each mismatch flips two bits in the 5-bit
+/// one-hot encoding, hence the `/ 2`.
+#[inline]
+fn hamming(a: &SeqEncoding, b: &SeqEncoding) -> usize {
+    a.0.iter()
+        .zip(b.0.iter())
+        .map(|(x, y)| (x ^ y).count_ones() as usize)
+        .sum::<usize>()
+        / 2
+}
+
+/// FNV-1a hash of the (canonical) 5-bit codes covering nucleotide positions
+/// `[start, end)` of an encoding. Identical band content always yields an
+/// identical key; hash collisions only ever add extra candidates (never drop
+/// true ones), so they cost time, not correctness.
+#[inline]
+fn band_hash(enc: &SeqEncoding, start: usize, end: usize) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for i in start..end {
+        let code = (enc.0[i / 12] >> (5 * (i % 12))) & 0x1f;
+        h ^= code;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// Identity hasher for band keys: the keys are already well-mixed FNV hashes,
+/// so we avoid SipHash and bucket directly on the u64.
+#[derive(Default)]
+struct U64Hasher(u64);
+impl Hasher for U64Hasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i;
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        for &b in bytes {
+            self.0 = self.0.rotate_left(8) ^ b as u64;
+        }
+    }
+}
+type U64Map = HashMap<u64, Vec<u32>, BuildHasherDefault<U64Hasher>>;
+
+/// Pigeonhole / banding index over centroids.
+///
+/// For a maximum Hamming divergence `d`, the sequence is split into `d + 1`
+/// disjoint contiguous bands. Any two sequences within distance `d` must have
+/// at least one band that is identical (d mismatches cannot touch all d+1
+/// bands), so a centroid within `d` of a query is guaranteed to share a band
+/// with it. The index therefore lets us restrict the (expensive) full-distance
+/// comparisons to centroids that share at least one band, turning the greedy
+/// scan from O(K) per query towards near-constant when clusters are dense.
+///
+/// This is exact for Hamming distance: it never misses a centroid within `d`.
+/// (Used only when `d + 1 < len`; otherwise a single all-differing pair could
+/// share no band, so the caller falls back to a full scan.)
+struct BandIndex {
+    bounds: Vec<(usize, usize)>,
+    maps: Vec<U64Map>,
+}
+
+impl BandIndex {
+    fn new(max_divergence: usize, len: usize) -> Self {
+        let num_bands = (max_divergence + 1).min(len.max(1));
+        let bounds = (0..num_bands)
+            .map(|i| (i * len / num_bands, (i + 1) * len / num_bands))
+            .collect();
+        let maps = (0..num_bands).map(|_| U64Map::default()).collect();
+        BandIndex { bounds, maps }
+    }
+
+    fn keys(&self, enc: &SeqEncoding) -> Vec<u64> {
+        self.bounds
+            .iter()
+            .map(|&(s, e)| band_hash(enc, s, e))
+            .collect()
+    }
+
+    /// Centroid indices that share at least one band with the given keys,
+    /// sorted ascending and deduplicated. Ascending order means a later
+    /// strict-`<` scan keeps the lowest-index centroid on distance ties,
+    /// matching the original greedy behaviour.
+    fn candidates_sorted(&self, keys: &[u64]) -> Vec<u32> {
+        let mut v = Vec::new();
+        for (b, &k) in keys.iter().enumerate() {
+            if let Some(list) = self.maps[b].get(&k) {
+                v.extend_from_slice(list);
+            }
+        }
+        v.sort_unstable();
+        v.dedup();
+        v
+    }
+
+    fn insert(&mut self, idx: u32, keys: &[u64]) {
+        for (b, &k) in keys.iter().enumerate() {
+            self.maps[b].entry(k).or_default().push(idx);
+        }
+    }
+}
+
+/// Greedy single-linkage-style centroid clustering, parallelised by block
+/// (phase 1 across sequences) and, when divergence is small relative to the
+/// sequence length, accelerated with a pigeonhole/banding index so that each
+/// sequence is only compared against plausible centroids rather than all of
+/// them.
+///
+/// Output is identical to the original serial implementation: the same
+/// lowest-index-at-minimum-distance assignment, the same new-centroid ordering
+/// and the same exact-duplicate filtering.
 pub fn cluster(
     input_fasta: &Path,
     max_divergence: u32,
@@ -18,76 +141,155 @@ pub fn cluster(
     let start = Instant::now();
     let max_divergence_usize = max_divergence as usize;
 
-    // Create vec of centroids - version not used, so zero
+    // All accepted centroids, in creation (= input) order.
     let mut centroids = WindowSet::new(0);
 
+    // Exact-duplicate filter: identical encodings are collapsed and not emitted.
     let mut seen_sequences = HashSet::<Vec<u64>>::new();
 
-    // Iterate input sequences
-    // Open the query file as a fasta file.
     let mut query_reader = parse_fastx_file(input_fasta).expect("valid path/file of input fasta");
 
-    // Pre-initialise the distances vector so don't have to continually reallocate.
-    let mut distances = vec![];
+    // Buffer output: the original wrote each line straight to an unbuffered
+    // stdout, a large syscall overhead at tens of millions of lines.
+    let mut out = BufWriter::new(print_stream);
 
     info!("Clustering ..");
-    let mut query_number: u32 = 0;
-    while let Some(record) = query_reader.next() {
-        query_number += 1;
+    let mut query_number: u64 = 0; // total records read (including duplicates)
+    let mut n_unique: u64 = 0;
 
-        // Encode as vec of bools
-        let record_unwrapped = record.expect("Failed to parse input sequence");
-        let seq = record_unwrapped.seq();
-        //let query_vec = seq.iter().map(|c| encode_single(*c)).collect::<Vec<_>>();
-        let query_vec =
-            SeqEncodingLength::from_bytes(record_unwrapped.id(), &record_unwrapped.seq());
+    let mut block: Vec<(Vec<u8>, SeqEncodingLength)> = Vec::with_capacity(BLOCK_SIZE);
 
-        // Skip if sequence has already been seen (in which case insert returns false)
-        if !seen_sequences.insert(query_vec.encoding.0.clone()) {
-            continue;
-        }
+    // Banding strategy is decided once the sequence length is known (all
+    // sequences must be the same length). `band_index` is `None` when banding
+    // is not used, in which case phase 1 falls back to a full centroid scan.
+    let mut initialized = false;
+    let mut band_index: Option<BandIndex> = None;
 
-        // Get distances
-        centroids.get_distances(&query_vec, &mut distances);
-
-        // Find min distance and index of it
-        let min_distance = if distances.is_empty() {
-            max_divergence_usize * 2 + 2
-        } else {
-            *(distances.iter().min().unwrap())
-        };
-
-        // If distance < max_divergence then add to centroid
-        let mut assigned_centroid = 0;
-        if min_distance <= max_divergence_usize {
-            for (i, distance) in distances.iter().enumerate() {
-                if *distance == min_distance {
-                    assigned_centroid = i;
+    let mut reader_done = false;
+    while !reader_done {
+        // ---- Fill a block with up to BLOCK_SIZE unique sequences ----
+        block.clear();
+        while block.len() < BLOCK_SIZE {
+            match query_reader.next() {
+                Some(record) => {
+                    query_number += 1;
+                    let record = record.expect("Failed to parse input sequence");
+                    let seq = record.seq();
+                    let enc = SeqEncodingLength::from_bytes(record.id(), &seq);
+                    if !seen_sequences.insert(enc.encoding.0.clone()) {
+                        continue;
+                    }
+                    block.push((seq.to_vec(), enc));
+                }
+                None => {
+                    reader_done = true;
                     break;
                 }
             }
-        } else {
-            // If distance >= max_divergence then add to new centroid
-            assigned_centroid = centroids.windows.len();
-            centroids.push_encoding(query_vec);
-            distances.push(0); // Adding another entry so that distances.len() == centroids.windows.len()
         }
-        debug!("Assigned centroid: {}", assigned_centroid);
-        debug!("windows len: {}", centroids.windows.len());
+        if block.is_empty() {
+            break;
+        }
+        n_unique += block.len() as u64;
 
-        // Print the sequence and the centroid it belongs to
-        writeln!(
-            print_stream,
-            "{}\t{}",
-            std::str::from_utf8(&seq).unwrap(),
-            centroids.get_as_string(assigned_centroid)
-        )?;
+        if !initialized {
+            let len = block[0].1.len;
+            // Banding needs d + 1 < len to guarantee a shared band for every
+            // within-d pair; otherwise fall back to full scans.
+            if max_divergence_usize + 1 < len {
+                band_index = Some(BandIndex::new(max_divergence_usize, len));
+            }
+            initialized = true;
+        }
+
+        // ---- Phase 1 (parallel): nearest pre-block centroid for each member ----
+        // `centroids` and `band_index` are immutable here, so each member is
+        // scored independently across threads. Returns the member's band keys
+        // (for later insertion) alongside its best pre-block hit.
+        let phase1: Vec<(Vec<u64>, (usize, usize))> = {
+            let centroids_ref = &centroids;
+            let bi_ref = band_index.as_ref();
+            block
+                .par_iter()
+                .with_min_len(64)
+                .map(|(_, enc)| match bi_ref {
+                    Some(bi) => {
+                        let keys = bi.keys(&enc.encoding);
+                        let mut best = (usize::MAX, usize::MAX);
+                        for idx in bi.candidates_sorted(&keys) {
+                            let d = hamming(&centroids_ref.windows[idx as usize], &enc.encoding);
+                            if d < best.0 {
+                                best = (d, idx as usize);
+                            }
+                        }
+                        (keys, best)
+                    }
+                    None => (Vec::new(), centroids_ref.nearest(enc)),
+                })
+                .collect()
+        };
+
+        // ---- Phase 2 (serial): reconcile within the block, in input order ----
+        // Members may match a centroid minted earlier in this same block; that
+        // set (`block_new`) is small, so a direct scan is fine.
+        let base = centroids.windows.len();
+        let mut block_new = WindowSet::new(0);
+        let mut assignments: Vec<usize> = Vec::with_capacity(block.len());
+        let mut minted: Vec<usize> = Vec::new(); // member indices that became centroids
+
+        for (j, (_, enc)) in block.iter().enumerate() {
+            let cand_existing = phase1[j].1; // (dist, global index < base) or (MAX, MAX)
+
+            let cand_new = if block_new.windows.is_empty() {
+                (usize::MAX, usize::MAX)
+            } else {
+                let (d, i) = block_new.nearest(enc);
+                (d, base + i)
+            };
+
+            // Pre-block indices < base <= any in-block index, so a lexicographic
+            // min reproduces the lowest-index tie-break across both sets.
+            let (best_d, best_idx) = std::cmp::min(cand_existing, cand_new);
+
+            if best_d <= max_divergence_usize {
+                assignments.push(best_idx);
+            } else {
+                let local = block_new.windows.len();
+                block_new.push_encoding(enc.clone());
+                assignments.push(base + local);
+                minted.push(j);
+            }
+        }
+
+        // Add this block's new centroids to the band index (global indices are
+        // assigned in mint order: the k-th minted centroid is `base + k`).
+        if let Some(bi) = band_index.as_mut() {
+            for (k, &j) in minted.iter().enumerate() {
+                bi.insert((base + k) as u32, &phase1[j].0);
+            }
+        }
+
+        // Make the new centroids globally visible before rendering output.
+        centroids.merge(block_new);
+
+        // ---- Emit output for the block, in input order ----
+        for ((seq_bytes, _), assigned) in block.iter().zip(assignments.iter()) {
+            writeln!(
+                out,
+                "{}\t{}",
+                std::str::from_utf8(seq_bytes).unwrap(),
+                centroids.get_as_string(*assigned)
+            )?;
+        }
     }
 
+    out.flush()?;
+
     info!(
-        "Clustering complete, took {} seconds. Clustered {} sequences into {} clusters.",
+        "Clustering complete, took {} seconds. Clustered {} sequences ({} unique) into {} clusters.",
         start.elapsed().as_secs(),
         query_number,
+        n_unique,
         centroids.windows.len()
     );
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,16 @@ use std::{error::Error, fs::File};
 use log::{debug, info};
 
 mod cluster;
-pub use cluster::{cluster, ClusterBanding};
+pub use cluster::cluster;
 
 pub const AUTHOR_AND_EMAIL: &str =
     "Ben J. Woodcroft, Centre for Microbiome Research, School of Biomedical Sciences, Faculty of Health, Queensland University of Technology <benjwoodcroft near gmail.com>";
 
 pub const CURRENT_DB_VERSION: u32 = 2;
+// NOTE: when this version is next bumped, cache the per-column conservation
+// weights (see `column_weights`) in the new DB format. `query` and `cluster`
+// currently recompute them at load to build the balanced band partition (~10 ms
+// for ~137k subjects); storing them would make that free. See BANDING_BENCHMARK.md.
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct SeqEncoding(Vec<u64>);
@@ -488,11 +492,14 @@ pub fn query(
         (false, Some(d)) if !windows.windows.is_empty() && (d as usize) + 1 < window_len => {
             let d = d as usize;
             info!(
-                "Building band index over {} subjects ({} bands) ..",
+                "Building balanced band index over {} subjects ({} bands) ..",
                 windows.windows.len(),
                 d + 1
             );
-            let mut bi = BandIndex::new(d, window_len);
+            // Entropy-balanced partition: column conservation is recomputed from
+            // the subjects at load (~10 ms for ~137k subjects), so no DB-format
+            // change is needed. Exact like any d+1-band partition.
+            let mut bi = BandIndex::single_balanced(d, window_len, &windows.windows);
             for (i, w) in windows.windows.iter().enumerate() {
                 let keys = bi.keys(w);
                 bi.insert(i as u32, &keys);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use std::{error::Error, fs::File};
 use log::{debug, info};
 
 mod cluster;
-pub use cluster::cluster;
+pub use cluster::{cluster, ClusterBanding};
 
 pub const AUTHOR_AND_EMAIL: &str =
     "Ben J. Woodcroft, Centre for Microbiome Research, School of Biomedical Sciences, Faculty of Health, Queensland University of Technology <benjwoodcroft near gmail.com>";
@@ -200,14 +200,24 @@ pub(crate) fn hamming(a: &SeqEncoding, b: &SeqEncoding) -> usize {
         / 2
 }
 
-/// FNV-1a hash of the (canonical) 5-bit codes covering nucleotide positions
-/// `[start, end)` of an encoding. Identical band content always yields an
-/// identical key; hash collisions only ever add extra candidates (never drop
-/// true ones), so they cost time, not correctness.
+/// A band is the set of nucleotide column indices it covers. For the original
+/// contiguous bands this is just a range; allowing an arbitrary column list lets
+/// a band be entropy-balanced (non-contiguous) while the pigeonhole guarantee —
+/// which only needs the bands to be a disjoint cover — still holds.
+type Band = Vec<usize>;
+
+/// FNV-1a hash of the (canonical) 5-bit codes at the given nucleotide column
+/// positions of an encoding. Identical band content (same columns, same order)
+/// always yields an identical key; hash collisions only ever add extra
+/// candidates (never drop true ones), so they cost time, not correctness.
+///
+/// FNV is order-dependent, so the same `cols` ordering must be used to index a
+/// subject and to probe with a query — guaranteed here because both go through
+/// the same `Partition`.
 #[inline]
-fn band_hash(enc: &SeqEncoding, start: usize, end: usize) -> u64 {
+fn band_hash(enc: &SeqEncoding, cols: &[usize]) -> u64 {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-    for i in start..end {
+    for &i in cols {
         let code = (enc.0[i / 12] >> (5 * (i % 12))) & 0x1f;
         h ^= code;
         h = h.wrapping_mul(0x0000_0100_0000_01b3);
@@ -236,44 +246,129 @@ impl Hasher for U64Hasher {
 }
 type U64Map = HashMap<u64, Vec<u32>, BuildHasherDefault<U64Hasher>>;
 
+/// The number of bands in one pigeonhole partition for divergence `d`: `d + 1`,
+/// capped at `len` so every band is non-empty.
+fn num_bands(d: usize, len: usize) -> usize {
+    (d + 1).min(len.max(1))
+}
+
+/// The original contiguous partition: `d + 1` equal-width contiguous bands.
+fn contiguous_bands(d: usize, len: usize) -> Vec<Band> {
+    let nb = num_bands(d, len);
+    (0..nb)
+        .map(|i| (i * len / nb..(i + 1) * len / nb).collect())
+        .collect()
+}
+
+/// Per-column collision weight `w = -ln(sum_i p_i^2)` over the subjects' allele
+/// frequencies. A fully conserved column has `w ≈ 0`; a uniform/wobble column
+/// has `w ≈ ln(4)`. Bands with equal summed weight have equal expected
+/// background collision probability, which (by convexity of `exp(-x)`) minimises
+/// the total candidate count.
+fn column_weights(windows: &[SeqEncoding], len: usize) -> Vec<f64> {
+    (0..len)
+        .map(|c| {
+            let mut counts = [0u64; 32];
+            for w in windows {
+                let code = ((w.0[c / 12] >> (5 * (c % 12))) & 0x1f) as usize;
+                counts[code] += 1;
+            }
+            let total: u64 = counts.iter().sum();
+            if total == 0 {
+                return 0.0;
+            }
+            let m: f64 = counts
+                .iter()
+                .map(|&ct| {
+                    let p = ct as f64 / total as f64;
+                    p * p
+                })
+                .sum();
+            -m.max(1e-12).ln()
+        })
+        .collect()
+}
+
+/// Entropy-balanced band assignment. Columns are ranked by weight (descending);
+/// the column at rank `r` is round-robined to band `r % nb`, so every band draws
+/// one column from each weight tier and ends up with near-equal summed weight —
+/// no band is left all-conserved (which is what creates a giant candidate
+/// bucket on coding data). Returns the band index for each column.
+fn balanced_assignment(d: usize, len: usize, weights: &[f64]) -> Vec<usize> {
+    let nb = num_bands(d, len);
+    let mut order: Vec<usize> = (0..len).collect();
+    order.sort_by(|&a, &b| {
+        weights[b]
+            .partial_cmp(&weights[a])
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.cmp(&b))
+    });
+    let mut slot = vec![0usize; len];
+    for (rank, &col) in order.iter().enumerate() {
+        slot[col] = rank % nb;
+    }
+    slot
+}
+
+fn slots_to_bands(slots: &[usize], nb: usize) -> Vec<Band> {
+    let mut bands = vec![Vec::new(); nb];
+    for (col, &s) in slots.iter().enumerate() {
+        bands[s].push(col);
+    }
+    bands
+}
+
 /// Pigeonhole / banding index.
 ///
-/// For a maximum Hamming divergence `d`, a sequence is split into `d + 1`
-/// disjoint contiguous bands. Any two sequences within distance `d` must share
-/// at least one identical band (d mismatches cannot touch all d+1 bands), so a
-/// subject within `d` of a query is guaranteed to share a band with it. The
-/// index maps `band position -> band hash -> subject indices`, restricting the
-/// full-distance comparisons to subjects that share a band.
+/// For a maximum Hamming divergence `d`, the sequence is split into `d + 1`
+/// disjoint bands. Any two sequences within distance `d` must share at least one
+/// identical band (d mismatches cannot touch all d+1 bands), so the candidate set
+/// is the union of the query's band buckets — every within-`d` subject is in it.
+/// The bands may be contiguous (`new`) or entropy-balanced (`single_balanced`);
+/// balancing spreads conserved columns across bands so no single band's bucket
+/// holds most of the database, which is the dominant cost on coding data.
 ///
 /// Exact for Hamming distance: it never misses a within-`d` subject. Valid only
 /// when `d + 1 <= len` (otherwise an all-differing pair could share no band);
 /// callers use it only when `d + 1 < len` and fall back to a full scan
 /// otherwise.
 pub(crate) struct BandIndex {
-    bounds: Vec<(usize, usize)>,
+    bands: Vec<Band>,
     maps: Vec<U64Map>,
 }
 
 impl BandIndex {
+    fn from_bands(bands: Vec<Band>) -> Self {
+        let maps = (0..bands.len()).map(|_| U64Map::default()).collect();
+        BandIndex { bands, maps }
+    }
+
+    /// `d + 1` equal contiguous bands — the original scheme.
     pub(crate) fn new(max_divergence: usize, len: usize) -> Self {
-        let num_bands = (max_divergence + 1).min(len.max(1));
-        let bounds = (0..num_bands)
-            .map(|i| (i * len / num_bands, (i + 1) * len / num_bands))
-            .collect();
-        let maps = (0..num_bands).map(|_| U64Map::default()).collect();
-        BandIndex { bounds, maps }
+        Self::from_bands(contiguous_bands(max_divergence, len))
+    }
+
+    /// A single entropy-balanced partition. Same number of bands and lookups as
+    /// `new`, but the columns are balanced by conservation (computed from
+    /// `windows`), which shrinks the candidate sets on coding data.
+    pub(crate) fn single_balanced(
+        max_divergence: usize,
+        len: usize,
+        windows: &[SeqEncoding],
+    ) -> Self {
+        let nb = num_bands(max_divergence, len);
+        let w = column_weights(windows, len);
+        let a = balanced_assignment(max_divergence, len, &w);
+        Self::from_bands(slots_to_bands(&a, nb))
     }
 
     pub(crate) fn keys(&self, enc: &SeqEncoding) -> Vec<u64> {
-        self.bounds
-            .iter()
-            .map(|&(s, e)| band_hash(enc, s, e))
-            .collect()
+        self.bands.iter().map(|b| band_hash(enc, b)).collect()
     }
 
-    /// Subject indices that share at least one band with the given keys, sorted
-    /// ascending and deduplicated. Ascending order means a later strict-`<`
-    /// scan keeps the lowest-index subject on distance ties.
+    /// Subject indices sharing at least one band with the query, sorted ascending
+    /// and deduplicated. Ascending order means a later strict-`<` scan keeps the
+    /// lowest-index subject on distance ties.
     pub(crate) fn candidates_sorted(&self, keys: &[u64]) -> Vec<u32> {
         let mut v = Vec::new();
         for (b, &k) in keys.iter().enumerate() {
@@ -590,6 +685,171 @@ pub fn query(
         "Querying complete, took {} seconds",
         start.elapsed().as_secs()
     );
+    Ok(())
+}
+
+/// Load a v2 DB file into a `WindowSet`.
+fn load_windows(db_path: &Path) -> Result<WindowSet, Box<dyn Error>> {
+    let mut ferris_file = File::open(db_path)?;
+    let mut buffer = Vec::new();
+    ferris_file.read_to_end(&mut buffer)?;
+    let version: u32 = postcard::from_bytes(&buffer[0..4])?;
+    if version != CURRENT_DB_VERSION {
+        panic!("Unsupported db file version: {version}");
+    }
+    Ok(postcard::from_bytes(&buffer)?)
+}
+
+/// One banding strategy under test in `bench_banding`.
+struct BenchMethod {
+    label: &'static str,
+    index: BandIndex,
+    build_secs: f64,
+    cand_total: u128,
+    cand_max: usize,
+    scan_secs: f64,
+}
+
+/// Benchmark the query-side banding strategies against each other on a real DB
+/// and query set: the single contiguous band (the current default) versus the
+/// single entropy-balanced band. For each divergence it reports the candidate-set
+/// size (the work that decides query speed) and the wall time, and asserts both
+/// strategies return the identical set of within-`d` hits — so
+/// the only thing that differs is how many false candidates each scans.
+pub fn bench_banding(
+    db_path: &Path,
+    query_fasta: &Path,
+    divergences: &[u32],
+    max_queries: Option<usize>,
+) -> Result<(), Box<dyn Error>> {
+    info!("Loading DB {db_path:?} ..");
+    let windows = load_windows(db_path)?;
+    let len = windows.len.map(NonZeroUsize::get).unwrap_or(0);
+    let subjects = &windows.windows;
+    info!("DB has {} subjects of length {len}", subjects.len());
+
+    info!("Loading queries {query_fasta:?} ..");
+    let mut query_reader = parse_fastx_file(query_fasta)?;
+    let mut queries: Vec<SeqEncoding> = Vec::new();
+    while let Some(record) = query_reader.next() {
+        let record = record?;
+        let enc = SeqEncodingLength::from_bytes(record.id(), &record.seq());
+        if enc.len != len {
+            panic!("Query length {} != subject length {len}", enc.len);
+        }
+        queries.push(enc.encoding);
+        if let Some(m) = max_queries {
+            if queries.len() >= m {
+                break;
+            }
+        }
+    }
+    let q = queries.len();
+    info!("Loaded {q} queries");
+
+    // How long does the entropy (per-column conservation) computation take? It
+    // depends only on the subjects, so it is paid once per query invocation if
+    // recomputed at load rather than stored in the DB.
+    {
+        let reps = 20;
+        let t = Instant::now();
+        let mut sink = 0.0f64;
+        for _ in 0..reps {
+            let w = column_weights(subjects, len);
+            sink += w.iter().sum::<f64>();
+        }
+        std::hint::black_box(sink);
+        println!(
+            "# entropy (column_weights) over {} subjects: {:.3} ms/call",
+            subjects.len(),
+            t.elapsed().as_secs_f64() * 1000.0 / reps as f64
+        );
+    }
+
+    println!("# subjects={} len={} queries={}", subjects.len(), len, q);
+    println!(
+        "{:<14} {:>11} {:>11} {:>9} {:>11} {:>10} {:>9}",
+        "method", "entries/sub", "build_s", "mean_cand", "total_cand", "max_cand", "scan_s"
+    );
+
+    for &dd in divergences {
+        let d = dd as usize;
+        if d + 1 >= len {
+            println!("# d={dd}: skipped (d+1 >= len, banding degenerate)");
+            continue;
+        }
+        let nb = num_bands(d, len);
+
+        // Build each index, timing the build (insert of every subject).
+        let build = |label: &'static str, mut index: BandIndex| -> BenchMethod {
+            let t = Instant::now();
+            for (i, w) in subjects.iter().enumerate() {
+                let keys = index.keys(w);
+                index.insert(i as u32, &keys);
+            }
+            BenchMethod {
+                label,
+                index,
+                build_secs: t.elapsed().as_secs_f64(),
+                cand_total: 0,
+                cand_max: 0,
+                scan_secs: 0.0,
+            }
+        };
+
+        let mut methods = vec![
+            build("contiguous", BandIndex::new(d, len)),
+            build("balanced", BandIndex::single_balanced(d, len, subjects)),
+        ];
+
+        // One pass over the queries; for each query every method computes its
+        // candidate set and its within-d hit set. The hit sets must match.
+        let mut mismatches = 0u64;
+        for query in &queries {
+            let mut reference_hits: Option<Vec<u32>> = None;
+            for m in methods.iter_mut() {
+                let t = Instant::now();
+                let keys = m.index.keys(query);
+                let cand = m.index.candidates_sorted(&keys);
+                let hits: Vec<u32> = cand
+                    .iter()
+                    .copied()
+                    .filter(|&i| hamming(&subjects[i as usize], query) <= d)
+                    .collect();
+                m.scan_secs += t.elapsed().as_secs_f64();
+                m.cand_total += cand.len() as u128;
+                m.cand_max = m.cand_max.max(cand.len());
+                match &reference_hits {
+                    None => reference_hits = Some(hits),
+                    Some(r) => {
+                        if &hits != r {
+                            mismatches += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        println!("# d={dd}  bands={nb}");
+        for m in &methods {
+            println!(
+                "{:<14} {:>11} {:>11.3} {:>9.2} {:>11} {:>10} {:>9.3}",
+                m.label,
+                nb,
+                m.build_secs,
+                m.cand_total as f64 / q as f64,
+                m.cand_total,
+                m.cand_max,
+                m.scan_secs,
+            );
+        }
+        if mismatches == 0 {
+            println!("# d={dd}: all methods returned identical within-d hits (OK)");
+        } else {
+            println!("# d={dd}: *** {mismatches} queries had differing hit sets ***");
+        }
+    }
+
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,7 @@ type Band = Vec<usize>;
 ///
 /// FNV is order-dependent, so the same `cols` ordering must be used to index a
 /// subject and to probe with a query — guaranteed here because both go through
-/// the same `Partition`.
+/// the same `BandIndex` bands.
 #[inline]
 fn band_hash(enc: &SeqEncoding, cols: &[usize]) -> u64 {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 use needletail::parse_fastx_file;
 use serde::{Deserialize, Serialize};
 
+use std::collections::HashMap;
+use std::hash::{BuildHasherDefault, Hasher};
 use std::io::{Read, Write};
 use std::num::{NonZeroU8, NonZeroUsize};
 use std::path::{Path, PathBuf};
@@ -186,6 +188,111 @@ impl WindowSet {
     }
 }
 
+/// Hamming distance between two equal-length packed encodings, in number of
+/// differing nucleotide positions. Each mismatch flips two bits in the 5-bit
+/// one-hot encoding, hence the `/ 2`.
+#[inline]
+pub(crate) fn hamming(a: &SeqEncoding, b: &SeqEncoding) -> usize {
+    a.0.iter()
+        .zip(b.0.iter())
+        .map(|(x, y)| (x ^ y).count_ones() as usize)
+        .sum::<usize>()
+        / 2
+}
+
+/// FNV-1a hash of the (canonical) 5-bit codes covering nucleotide positions
+/// `[start, end)` of an encoding. Identical band content always yields an
+/// identical key; hash collisions only ever add extra candidates (never drop
+/// true ones), so they cost time, not correctness.
+#[inline]
+fn band_hash(enc: &SeqEncoding, start: usize, end: usize) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for i in start..end {
+        let code = (enc.0[i / 12] >> (5 * (i % 12))) & 0x1f;
+        h ^= code;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// Identity hasher for band keys: the keys are already well-mixed FNV hashes,
+/// so we avoid SipHash and bucket directly on the u64.
+#[derive(Default)]
+struct U64Hasher(u64);
+impl Hasher for U64Hasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i;
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        for &b in bytes {
+            self.0 = self.0.rotate_left(8) ^ b as u64;
+        }
+    }
+}
+type U64Map = HashMap<u64, Vec<u32>, BuildHasherDefault<U64Hasher>>;
+
+/// Pigeonhole / banding index.
+///
+/// For a maximum Hamming divergence `d`, a sequence is split into `d + 1`
+/// disjoint contiguous bands. Any two sequences within distance `d` must share
+/// at least one identical band (d mismatches cannot touch all d+1 bands), so a
+/// subject within `d` of a query is guaranteed to share a band with it. The
+/// index maps `band position -> band hash -> subject indices`, restricting the
+/// full-distance comparisons to subjects that share a band.
+///
+/// Exact for Hamming distance: it never misses a within-`d` subject. Valid only
+/// when `d + 1 <= len` (otherwise an all-differing pair could share no band);
+/// callers use it only when `d + 1 < len` and fall back to a full scan
+/// otherwise.
+pub(crate) struct BandIndex {
+    bounds: Vec<(usize, usize)>,
+    maps: Vec<U64Map>,
+}
+
+impl BandIndex {
+    pub(crate) fn new(max_divergence: usize, len: usize) -> Self {
+        let num_bands = (max_divergence + 1).min(len.max(1));
+        let bounds = (0..num_bands)
+            .map(|i| (i * len / num_bands, (i + 1) * len / num_bands))
+            .collect();
+        let maps = (0..num_bands).map(|_| U64Map::default()).collect();
+        BandIndex { bounds, maps }
+    }
+
+    pub(crate) fn keys(&self, enc: &SeqEncoding) -> Vec<u64> {
+        self.bounds
+            .iter()
+            .map(|&(s, e)| band_hash(enc, s, e))
+            .collect()
+    }
+
+    /// Subject indices that share at least one band with the given keys, sorted
+    /// ascending and deduplicated. Ascending order means a later strict-`<`
+    /// scan keeps the lowest-index subject on distance ties.
+    pub(crate) fn candidates_sorted(&self, keys: &[u64]) -> Vec<u32> {
+        let mut v = Vec::new();
+        for (b, &k) in keys.iter().enumerate() {
+            if let Some(list) = self.maps[b].get(&k) {
+                v.extend_from_slice(list);
+            }
+        }
+        v.sort_unstable();
+        v.dedup();
+        v
+    }
+
+    pub(crate) fn insert(&mut self, idx: u32, keys: &[u64]) {
+        for (b, &k) in keys.iter().enumerate() {
+            self.maps[b].entry(k).or_default().push(idx);
+        }
+    }
+}
+
 pub fn makedb(subject_fasta: &Path, db_path: &Path) -> Result<(), Box<dyn Error>> {
     // Iterate over lines, creating a vector of u8, where the lowest 5 bits of the u8
     // are the input nucleotides, one-hot encoded
@@ -253,6 +360,7 @@ pub fn query(
     max_divergence: Option<u32>,
     max_num_hits: Option<u32>,
     limit_per_sequence: Option<u32>,
+    no_banding: bool,
 ) -> Result<(), Box<dyn Error>> {
     // Decode
     info!("Decoding db file {:?}", db_path);
@@ -275,8 +383,41 @@ pub fn query(
     // 1 is a special case, it is equivalent to None.
     let max_divergence_for_match = max_num_hits.filter(|&max_num_hits| max_num_hits != 1);
 
-    // Pre-initialise the distances vector so don't have to continually reallocate.
-    let mut distances = vec![0; windows.windows.len()];
+    // Banding (the pigeonhole prefilter) can only prune when there is a
+    // divergence bound: without one, the nearest hit could be arbitrarily far
+    // and share no band, so we must scan everything. It is also only used when
+    // d + 1 < window length (a tighter bound makes the bands degenerate and the
+    // candidate sets explode), and can be disabled explicitly for large d.
+    let window_len = windows.len.map(NonZeroUsize::get).unwrap_or(0);
+    let band_index: Option<BandIndex> = match (no_banding, max_divergence) {
+        (false, Some(d)) if !windows.windows.is_empty() && (d as usize) + 1 < window_len => {
+            let d = d as usize;
+            info!(
+                "Building band index over {} subjects ({} bands) ..",
+                windows.windows.len(),
+                d + 1
+            );
+            let mut bi = BandIndex::new(d, window_len);
+            for (i, w) in windows.windows.iter().enumerate() {
+                let keys = bi.keys(w);
+                bi.insert(i as u32, &keys);
+            }
+            Some(bi)
+        }
+        (false, Some(d)) if (d as usize) + 1 >= window_len && window_len > 0 => {
+            info!("Banding disabled (max-divergence too large for the window length); scanning all subjects.");
+            None
+        }
+        _ => None,
+    };
+
+    // Pre-initialise the distances vector so don't have to continually
+    // reallocate. Only needed for the full-scan path.
+    let mut distances = if band_index.is_none() {
+        vec![0; windows.windows.len()]
+    } else {
+        Vec::new()
+    };
 
     // Iterate over the query file.
     info!("Querying ..");
@@ -286,6 +427,87 @@ pub fn query(
         let record = record.expect("Failed to parse query sequence");
         let query_vec = SeqEncodingLength::from_bytes(record.id(), &record.seq());
 
+        if let Some(bi) = band_index.as_ref() {
+            // ---- Banded path (only reached when max_divergence is Some) ----
+            let max_div = max_divergence.unwrap() as usize;
+            let keys = bi.keys(&query_vec.encoding);
+            let mut cand: Vec<(usize, usize)> = bi
+                .candidates_sorted(&keys)
+                .into_iter()
+                .map(|i| {
+                    (
+                        hamming(&windows.windows[i as usize], &query_vec.encoding),
+                        i as usize,
+                    )
+                })
+                .collect();
+            // Sort by (distance, index): the within-d subset and its ordering
+            // then match the full-scan path exactly, including the lowest-index
+            // tie-break.
+            cand.sort_unstable();
+
+            match max_divergence_for_match {
+                Some(max_num_hits) => {
+                    // k-th smallest distance among candidates. Output is gated by
+                    // `<= max_div`, and every within-d subject is a candidate, so
+                    // this reproduces the full-scan top-k-within-d result.
+                    let max_distance = if max_num_hits > cand.len() as u32 {
+                        cand.iter().map(|(d, _)| *d).max().unwrap_or(0)
+                    } else {
+                        cand[(max_num_hits - 1) as usize].0
+                    };
+
+                    let mut last_sequence: Option<(String, u32)> = None;
+                    let mut new_last_sequence: Option<(String, u32)>;
+                    for (distance, i) in cand.iter() {
+                        if *distance <= max_distance && *distance <= max_div {
+                            let s = windows.get_as_string(*i);
+                            debug!("Found hit sequence {} at distance {}", s, distance);
+
+                            if let Some(limit_per_sequence_unwrapped) = limit_per_sequence {
+                                match &last_sequence {
+                                    Some((last_seq, last_seq_count)) if last_seq == &s => {
+                                        if last_seq_count >= &limit_per_sequence_unwrapped {
+                                            continue;
+                                        } else {
+                                            new_last_sequence =
+                                                Some((s.clone(), last_seq_count + 1));
+                                        }
+                                    }
+                                    _ => {
+                                        new_last_sequence = Some((s.clone(), 1));
+                                    }
+                                }
+                                last_sequence = new_last_sequence;
+                            }
+
+                            println!("{}\t{}\t{}\t{}", query_number, i, distance, s);
+                        }
+                    }
+                }
+                None => {
+                    if limit_per_sequence.is_some() {
+                        panic!("limit_per_sequence is implemented unless max_num_hits > 1. It can be implemented by analogy, just haven't gotten around to it.");
+                    }
+                    // Closest candidate; print all at that distance if within d.
+                    if let Some(min_distance) = cand.iter().map(|(d, _)| *d).min() {
+                        if min_distance <= max_div {
+                            for (distance, i) in cand.iter() {
+                                if *distance == min_distance {
+                                    let s = windows.get_as_string(*i);
+                                    println!("{}\t{}\t{}\t{}", query_number, i, distance, s);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            query_number += 1;
+            continue;
+        }
+
+        // ---- Full-scan path (no divergence bound, or banding disabled) ----
         // Get the minimum distance between the query and each window using xor.
         windows.get_distances(&query_vec, &mut distances);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,58 @@ impl WindowSet {
         }
     }
 
+    /// Serial nearest-centroid search. Returns `(distance, index)` of the
+    /// lowest-indexed window with the smallest Hamming distance to `seq`, or
+    /// `(usize::MAX, usize::MAX)` when there are no windows. The strict `<`
+    /// comparison keeps the first (lowest-index) window on ties, matching the
+    /// original greedy clustering behaviour.
+    fn nearest(&self, seq: &SeqEncodingLength) -> (usize, usize) {
+        if let Some(n) = self.len {
+            if n.get() != seq.len {
+                panic!(
+                    "{}",
+                    &format!("Cannot compute distances between seq of length {} and windows of lengths {}", seq.len, n.get())
+                )
+            }
+        }
+        let mut best = (usize::MAX, usize::MAX);
+        for (i, window) in self.windows.iter().enumerate() {
+            let d = window
+                .0
+                .iter()
+                .zip(seq.encoding.0.iter())
+                .map(|(a, b)| (a ^ b).count_ones() as usize)
+                .sum::<usize>()
+                / 2;
+            if d < best.0 {
+                best = (d, i);
+            }
+        }
+        best
+    }
+
+    /// Move all windows from `other` into `self`, preserving order.
+    fn merge(&mut self, mut other: WindowSet) {
+        if other.windows.is_empty() {
+            return;
+        }
+        match self.len {
+            Some(n) => {
+                if let Some(m) = other.len {
+                    if n.get() != m.get() {
+                        panic!(
+                            "Cannot merge WindowSets with differing sequence lengths {} and {}",
+                            n.get(),
+                            m.get()
+                        );
+                    }
+                }
+            }
+            None => self.len = other.len,
+        }
+        self.windows.append(&mut other.windows);
+    }
+
     fn push_encoding(&mut self, encoding: SeqEncodingLength) {
         if let Some(n) = self.len {
             if n.get() != encoding.len {
@@ -269,19 +321,14 @@ pub fn query(
                         if let Some(limit_per_sequence_unwrapped) = limit_per_sequence {
                             // limit per sequence
                             match &last_sequence {
-                                Some((last_seq, last_seq_count)) => {
-                                    if last_seq == &s {
-                                        if last_seq_count >= &limit_per_sequence_unwrapped {
-                                            continue;
-                                        } else {
-                                            new_last_sequence =
-                                                Some((s.clone(), last_seq_count + 1));
-                                        }
+                                Some((last_seq, last_seq_count)) if last_seq == &s => {
+                                    if last_seq_count >= &limit_per_sequence_unwrapped {
+                                        continue;
                                     } else {
-                                        new_last_sequence = Some((s.clone(), 1));
+                                        new_last_sequence = Some((s.clone(), last_seq_count + 1));
                                     }
                                 }
-                                None => {
+                                _ => {
                                     new_last_sequence = Some((s.clone(), 1));
                                 }
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,10 +45,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let max_divergence = m.get_one::<u32>("max-divergence").unwrap();
             let num_threads = *m.get_one::<usize>("threads").unwrap();
             let no_banding = m.get_flag("no-banding");
-            let banding = match m.get_one::<String>("banding").map(String::as_str) {
-                Some("contiguous") => smafa::ClusterBanding::Contiguous,
-                _ => smafa::ClusterBanding::Balanced,
-            };
             rayon::ThreadPoolBuilder::new()
                 .num_threads(num_threads)
                 .build_global()
@@ -57,7 +53,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 input_fasta,
                 *max_divergence,
                 no_banding,
-                banding,
                 &mut std::io::stdout(),
             )
         }
@@ -142,11 +137,6 @@ fn build_cli() -> Command {
                 )
                 .arg(
                     arg!(--"no-banding" "Disable the pigeonhole banding prefilter and scan all subjects. Banding is only used when --max-divergence is set and small relative to the window length; disable it for large --max-divergence.")
-                )
-                .arg(
-                    arg!(--banding <STRATEGY> "Banding partition strategy: balanced (entropy-balanced from the first block) or contiguous. Both give identical output; balanced is faster on coding data. [default: balanced]")
-                        .value_parser(["balanced", "contiguous"])
-                        .default_value("balanced"),
                 ),
         ))
         .subcommand(add_clap_verbosity_flags(

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,11 +44,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let input_fasta = m.get_one::<PathBuf>("input").unwrap();
             let max_divergence = m.get_one::<u32>("max-divergence").unwrap();
             let num_threads = *m.get_one::<usize>("threads").unwrap();
+            let no_banding = m.get_flag("no-banding");
             rayon::ThreadPoolBuilder::new()
                 .num_threads(num_threads)
                 .build_global()
                 .expect("Failed to initialise global thread pool");
-            smafa::cluster(input_fasta, *max_divergence, &mut std::io::stdout())
+            smafa::cluster(
+                input_fasta,
+                *max_divergence,
+                no_banding,
+                &mut std::io::stdout(),
+            )
         }
         Some("count") => {
             let m = matches.subcommand_matches("count").unwrap();
@@ -118,6 +124,9 @@ fn build_cli() -> Command {
                     arg!(-t --threads <INT> "Number of threads to use [default: 1]")
                         .value_parser(value_parser!(usize))
                         .default_value("1"),
+                )
+                .arg(
+                    arg!(--"no-banding" "Disable the pigeonhole banding prefilter and scan all subjects. Banding is only used when --max-divergence is set and small relative to the window length; disable it for large --max-divergence.")
                 ),
         ))
         .subcommand(add_clap_verbosity_flags(

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let max_divergence = m.get_one::<u32>("max-divergence").unwrap();
             let num_threads = *m.get_one::<usize>("threads").unwrap();
             let no_banding = m.get_flag("no-banding");
+            let banding = match m.get_one::<String>("banding").map(String::as_str) {
+                Some("contiguous") => smafa::ClusterBanding::Contiguous,
+                _ => smafa::ClusterBanding::Balanced,
+            };
             rayon::ThreadPoolBuilder::new()
                 .num_threads(num_threads)
                 .build_global()
@@ -53,8 +57,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 input_fasta,
                 *max_divergence,
                 no_banding,
+                banding,
                 &mut std::io::stdout(),
             )
+        }
+        Some("bench-banding") => {
+            let m = matches.subcommand_matches("bench-banding").unwrap();
+            set_log_level(m, true);
+            let database = m.get_one::<PathBuf>("database").unwrap();
+            let query_fasta = m.get_one::<PathBuf>("query").unwrap();
+            let divergences: Vec<u32> =
+                m.get_many::<u32>("divergences").unwrap().copied().collect();
+            let max_queries = m.get_one::<usize>("max-queries").copied();
+            smafa::bench_banding(database, query_fasta, &divergences, max_queries)
         }
         Some("count") => {
             let m = matches.subcommand_matches("count").unwrap();
@@ -127,6 +142,27 @@ fn build_cli() -> Command {
                 )
                 .arg(
                     arg!(--"no-banding" "Disable the pigeonhole banding prefilter and scan all subjects. Banding is only used when --max-divergence is set and small relative to the window length; disable it for large --max-divergence.")
+                )
+                .arg(
+                    arg!(--banding <STRATEGY> "Banding partition strategy: balanced (entropy-balanced from the first block) or contiguous. Both give identical output; balanced is faster on coding data. [default: balanced]")
+                        .value_parser(["balanced", "contiguous"])
+                        .default_value("balanced"),
+                ),
+        ))
+        .subcommand(add_clap_verbosity_flags(
+            Command::new("bench-banding")
+                .about("Benchmark query banding strategies (candidate-set size and speed) on a DB + query set")
+                .arg(arg!(-d --database <FILE> "Output from makedb [required]").required(true).value_parser(value_parser!(PathBuf)))
+                .arg(arg!(-q --query <FILE> "Query sequences in FASTX format [required]").required(true).value_parser(value_parser!(PathBuf)))
+                .arg(
+                    arg!(--divergences <INT> "Divergences to benchmark")
+                        .num_args(1..)
+                        .value_parser(value_parser!(u32))
+                        .default_values(["2", "3", "5"]),
+                )
+                .arg(
+                    arg!(--"max-queries" <INT> "Only use the first N queries [default: all]")
+                        .value_parser(value_parser!(usize)),
                 ),
         ))
         .subcommand(add_clap_verbosity_flags(

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             set_log_level(m, true);
             let input_fasta = m.get_one::<PathBuf>("input").unwrap();
             let max_divergence = m.get_one::<u32>("max-divergence").unwrap();
+            let num_threads = *m.get_one::<usize>("threads").unwrap();
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(num_threads)
+                .build_global()
+                .expect("Failed to initialise global thread pool");
             smafa::cluster(input_fasta, *max_divergence, &mut std::io::stdout())
         }
         Some("count") => {
@@ -103,6 +108,11 @@ fn build_cli() -> Command {
                 .arg(
                     arg!(-d --"max-divergence" <INT> "Maximum divergence to report hits for, for each sequence [default: not used]")
                         .value_parser(value_parser!(u32)),
+                )
+                .arg(
+                    arg!(-t --threads <INT> "Number of threads to use [default: 1]")
+                        .value_parser(value_parser!(usize))
+                        .default_value("1"),
                 ),
         ))
         .subcommand(add_clap_verbosity_flags(

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,12 +21,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let max_divergence = m.get_one::<u32>("max-divergence");
             let max_num_hits = m.get_one::<u32>("max-num-hits");
             let limit_per_sequence = m.get_one::<u32>("limit-per-sequence");
+            let no_banding = m.get_flag("no-banding");
             smafa::query(
                 db_root,
                 query_fasta,
                 max_divergence.copied(),
                 max_num_hits.copied(),
                 limit_per_sequence.copied(),
+                no_banding,
             )
         }
         Some("makedb") => {
@@ -99,6 +101,9 @@ fn build_cli() -> Command {
                 .arg(
                     arg!( --"limit-per-sequence" <INT> "Maximum number of hits to report per sequence. Requires --max-num-hits > 1 for now. [default: not used]")
                         .value_parser(value_parser!(u32)),
+                )
+                .arg(
+                    arg!(--"no-banding" "Disable the pigeonhole banding prefilter and scan all subjects. Banding is only used when --max-divergence is set and small relative to the window length; disable it for large --max-divergence.")
                 ),
         ))
         .subcommand(add_clap_verbosity_flags(

--- a/tests/test_cmdline.rs
+++ b/tests/test_cmdline.rs
@@ -246,6 +246,26 @@ mod tests {
             .unwrap()
     }
 
+    #[test]
+    fn test_cluster_multithreaded() {
+        Assert::main_binary()
+            .with_args(&[
+                "cluster",
+                "-i",
+                "tests/data/cluster_dummy1.fna",
+                "-d",
+                "1",
+                "-t",
+                "2",
+            ])
+            .succeeds()
+            .stdout()
+            .is("ATGC\tATGC\n\
+                ATGG\tATGC\n\
+                AAAA\tAAAA\n")
+            .unwrap()
+    }
+
     // #[test]
     // fn test_db_version_incompatibility(){
     //     Assert::main_binary()

--- a/tests/test_cmdline.rs
+++ b/tests/test_cmdline.rs
@@ -266,6 +266,27 @@ mod tests {
             .unwrap()
     }
 
+    #[test]
+    fn test_cluster_multithreaded_no_banding() {
+        Assert::main_binary()
+            .with_args(&[
+                "cluster",
+                "-i",
+                "tests/data/cluster_dummy1.fna",
+                "-d",
+                "1",
+                "--no-banding",
+                "-t",
+                "2",
+            ])
+            .succeeds()
+            .stdout()
+            .is("ATGC\tATGC\n\
+                ATGG\tATGC\n\
+                AAAA\tAAAA\n")
+            .unwrap()
+    }
+
     // #[test]
     // fn test_db_version_incompatibility(){
     //     Assert::main_binary()


### PR DESCRIPTION
## Idea

For a max Hamming divergence `d`, split each sequence into `d + 1` disjoint
contiguous bands. By pigeonhole, `d` mismatches cannot touch all `d + 1` bands,
so any centroid within distance `d` of a query has at least one band identical
to the query's. Indexing centroids by band value (`band position` →
`band hash` → centroid indices) lets phase 1 compare a sequence only against
centroids that share a band, instead of all K.

## Exactness

This is exact for Hamming distance — it never misses a centroid within `d`:

- A within-`d` centroid is guaranteed (pigeonhole) to be in the candidate set.
- Band-hash collisions can only add candidates, never drop them (a full
  distance check then discards the spurious ones), so they cost time only.
- Candidates are scanned in ascending index order, preserving the original
  "lowest-index centroid at the minimum distance" tie-break.
- Used only when `d + 1 < len`; for larger `d` an all-differing pair could
  share no band, so phase 1 falls back to the full scan (`WindowSet::nearest`).
- In-block new centroids are reconciled by a direct scan in phase 2 (bounded by
  `BLOCK_SIZE`), so cross-references within a block are handled exactly.

Verified byte-for-byte against the v0.8.0 serial binary on 9.4k- and
140k-sequence synthetic sets (clusters + exact duplicates + `-` gaps) at
`d = 0,1,2,3,6,10`, spanning single- and many-block runs, and confirmed
`-t 1` == `-t 4`. Existing unit + cmdline tests pass.

## Effect

Single-threaded, 140k sequences → 69k clusters at `d = 3`: ~58 s (full scan) →
~2.5 s (banded). The win is algorithmic (fewer comparisons), so it shows up
even on one core and compounds with the `--threads` parallelism. Benefit grows
as K grows and shrinks as `d` approaches `len`.

## Cost / notes

- Memory: the index holds `d + 1` maps of `band hash → Vec<centroid index>`
  (`u32` indices). For very large K and small `d` this is a few extra bytes per
  centroid per band — worth watching on the 45M run, and an easy future
  optimisation (e.g. a single arena instead of many small `Vec`s).
- Band keys use FNV-1a over the canonical 5-bit codes with an identity hasher
  (no SipHash). No new dependencies.